### PR TITLE
Fix #12 item cart

### DIFF
--- a/src/main/kotlin/com/highv/ecommerce/domain/item_cart/service/ItemCartService.kt
+++ b/src/main/kotlin/com/highv/ecommerce/domain/item_cart/service/ItemCartService.kt
@@ -24,15 +24,24 @@ class ItemCartService(
         val product: Product =
             productRepository.findByIdOrNull(productId) ?: throw RuntimeException("Product not found")
 
-        val item: ItemCart = ItemCart(
-            productId = productId,
-            productName = product.name,
-            price = 3000 * request.quantity, // 추후 프로덕트에서 price 관련된 게 생길 예정
-            quantity = request.quantity,
-            buyerId = buyerId
-        )
+        val existsCart: ItemCart? = itemCartRepository.findByProductIdAndBuyerIdAndIsDeletedFalse(productId, buyerId)
 
-        itemCartRepository.save(item)
+        if (existsCart != null) {
+            val quantity: Int = existsCart.quantity + request.quantity
+            existsCart.updateQuantityAndPrice(quantity, 3000)
+
+            itemCartRepository.save(existsCart)
+        } else {
+            val item: ItemCart = ItemCart(
+                productId = productId,
+                productName = product.name,
+                price = 3000 * request.quantity, // 추후 프로덕트에서 price 관련된 게 생길 예정
+                quantity = request.quantity,
+                buyerId = buyerId
+            )
+
+            itemCartRepository.save(item)
+        }
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 요약
> 장바구니에 상품 추가 로직 수정

## 작업 사항

> 장바구니에 상품 추가 시 중복으로 db에 저장되는 로직 수정
> db에 이미 존재할 경우 상품 수량 증가
---
### 해결한 이슈
closes: #12 
