### PR TITLE
Feat/#14 profile revision

### DIFF
--- a/src/main/kotlin/com/highv/ecommerce/domain/buyer/controller/BuyerController.kt
+++ b/src/main/kotlin/com/highv/ecommerce/domain/buyer/controller/BuyerController.kt
@@ -4,6 +4,7 @@ import com.highv.ecommerce.common.exception.LoginException
 import com.highv.ecommerce.domain.buyer.dto.request.CreateBuyerRequest
 import com.highv.ecommerce.domain.buyer.dto.request.UpdateBuyerImageRequest
 import com.highv.ecommerce.domain.buyer.dto.request.UpdateBuyerPasswordRequest
+import com.highv.ecommerce.domain.buyer.dto.request.UpdateBuyerProfileRequest
 import com.highv.ecommerce.domain.buyer.dto.response.BuyerResponse
 import com.highv.ecommerce.domain.buyer.service.BuyerService
 import com.highv.ecommerce.infra.security.UserPrincipal
@@ -15,6 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.validation.BindingResult
 import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -62,4 +64,13 @@ class BuyerController(private val buyerService: BuyerService) {
     ): ResponseEntity<Unit> = ResponseEntity
         .status(HttpStatus.OK)
         .body(buyerService.changeProfileImage(request, user.id))
+
+    @PreAuthorize("hasRole('BUYER')")
+    @PutMapping("/profile")
+    fun changeProfile(
+        @RequestBody request: UpdateBuyerProfileRequest,
+        @AuthenticationPrincipal user: UserPrincipal,
+    ): ResponseEntity<BuyerResponse> = ResponseEntity
+        .status(HttpStatus.OK)
+        .body(buyerService.changeProfile(request, user.id))
 }

--- a/src/main/kotlin/com/highv/ecommerce/domain/buyer/controller/BuyerController.kt
+++ b/src/main/kotlin/com/highv/ecommerce/domain/buyer/controller/BuyerController.kt
@@ -2,6 +2,7 @@ package com.highv.ecommerce.domain.buyer.controller
 
 import com.highv.ecommerce.common.exception.LoginException
 import com.highv.ecommerce.domain.buyer.dto.request.CreateBuyerRequest
+import com.highv.ecommerce.domain.buyer.dto.request.UpdateBuyerImageRequest
 import com.highv.ecommerce.domain.buyer.dto.request.UpdateBuyerPasswordRequest
 import com.highv.ecommerce.domain.buyer.dto.response.BuyerResponse
 import com.highv.ecommerce.domain.buyer.service.BuyerService
@@ -52,4 +53,13 @@ class BuyerController(private val buyerService: BuyerService) {
             .status(HttpStatus.OK)
             .body(buyerService.changePassword(request, user.id))
     }
+
+    @PreAuthorize("hasRole('BUYER')")
+    @PatchMapping("/profile/profile-image")
+    fun changeImage(
+        @RequestBody request: UpdateBuyerImageRequest,
+        @AuthenticationPrincipal user: UserPrincipal,
+    ): ResponseEntity<Unit> = ResponseEntity
+        .status(HttpStatus.OK)
+        .body(buyerService.changeProfileImage(request, user.id))
 }

--- a/src/main/kotlin/com/highv/ecommerce/domain/buyer/controller/BuyerController.kt
+++ b/src/main/kotlin/com/highv/ecommerce/domain/buyer/controller/BuyerController.kt
@@ -1,13 +1,18 @@
 package com.highv.ecommerce.domain.buyer.controller
 
 import com.highv.ecommerce.common.exception.LoginException
-import com.highv.ecommerce.domain.buyer.dto.BuyerResponse
-import com.highv.ecommerce.domain.buyer.dto.CreateBuyerRequest
+import com.highv.ecommerce.domain.buyer.dto.request.CreateBuyerRequest
+import com.highv.ecommerce.domain.buyer.dto.request.UpdateBuyerPasswordRequest
+import com.highv.ecommerce.domain.buyer.dto.response.BuyerResponse
 import com.highv.ecommerce.domain.buyer.service.BuyerService
+import com.highv.ecommerce.infra.security.UserPrincipal
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.validation.BindingResult
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -29,5 +34,22 @@ class BuyerController(private val buyerService: BuyerService) {
         return ResponseEntity
             .status(HttpStatus.CREATED)
             .body(buyerService.signUp(request))
+    }
+
+    @PreAuthorize("hasRole('BUYER')")
+    @PatchMapping("/profile/password")
+    fun changePassword(
+        @Valid @RequestBody request: UpdateBuyerPasswordRequest,
+        bindingResult: BindingResult,
+        @AuthenticationPrincipal user: UserPrincipal,
+    ): ResponseEntity<Unit> {
+
+        if (bindingResult.hasErrors()) {
+            throw RuntimeException(bindingResult.fieldError?.defaultMessage.toString())
+        }
+
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(buyerService.changePassword(request, user.id))
     }
 }

--- a/src/main/kotlin/com/highv/ecommerce/domain/buyer/dto/request/CreateBuyerRequest.kt
+++ b/src/main/kotlin/com/highv/ecommerce/domain/buyer/dto/request/CreateBuyerRequest.kt
@@ -1,4 +1,4 @@
-package com.highv.ecommerce.domain.buyer.dto
+package com.highv.ecommerce.domain.buyer.dto.request
 
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank

--- a/src/main/kotlin/com/highv/ecommerce/domain/buyer/dto/request/UpdateBuyerImageRequest.kt
+++ b/src/main/kotlin/com/highv/ecommerce/domain/buyer/dto/request/UpdateBuyerImageRequest.kt
@@ -1,0 +1,5 @@
+package com.highv.ecommerce.domain.buyer.dto.request
+
+data class UpdateBuyerImageRequest(
+    val imageUrl: String
+)

--- a/src/main/kotlin/com/highv/ecommerce/domain/buyer/dto/request/UpdateBuyerPasswordRequest.kt
+++ b/src/main/kotlin/com/highv/ecommerce/domain/buyer/dto/request/UpdateBuyerPasswordRequest.kt
@@ -1,0 +1,15 @@
+package com.highv.ecommerce.domain.buyer.dto.request
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class UpdateBuyerPasswordRequest(
+
+    val currentPassword: String,
+    @field : NotBlank(message = "비밀번호는 공백일 수 없습니다.")
+    @field : Size(min = 8, max = 30, message = "비밀번호는 최소 8자 이상 최대 30 이하입니다.")
+    val newPassword: String,
+    @field : NotBlank(message = "확인 비밀번호는 공백일 수 없습니다.")
+    @field : Size(min = 8, max = 30, message = "확인 비밀번호는 최소 8자 이상 최대 30 이하입니다.")
+    val confirmNewPassword: String
+)

--- a/src/main/kotlin/com/highv/ecommerce/domain/buyer/dto/request/UpdateBuyerProfileRequest.kt
+++ b/src/main/kotlin/com/highv/ecommerce/domain/buyer/dto/request/UpdateBuyerProfileRequest.kt
@@ -1,0 +1,7 @@
+package com.highv.ecommerce.domain.buyer.dto.request
+
+data class UpdateBuyerProfileRequest(
+    val nickname: String,
+    val phoneNumber: String,
+    val address: String
+)

--- a/src/main/kotlin/com/highv/ecommerce/domain/buyer/dto/response/BuyerResponse.kt
+++ b/src/main/kotlin/com/highv/ecommerce/domain/buyer/dto/response/BuyerResponse.kt
@@ -1,4 +1,4 @@
-package com.highv.ecommerce.domain.buyer.dto
+package com.highv.ecommerce.domain.buyer.dto.response
 
 import com.highv.ecommerce.domain.buyer.entity.Buyer
 

--- a/src/main/kotlin/com/highv/ecommerce/domain/buyer/entity/Buyer.kt
+++ b/src/main/kotlin/com/highv/ecommerce/domain/buyer/entity/Buyer.kt
@@ -1,27 +1,40 @@
 package com.highv.ecommerce.domain.buyer.entity
 
-import jakarta.persistence.*
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
 
 @Entity
 @Table(name = "buyer")
 class Buyer(
-   @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-   val id: Long? = null,
-   @Column(name = "nickname")
-   val nickname: String,
-   @Column(name = "password")
-   val password: String,
-   @Column(name = "email")
-   val email: String,
-   @Column(name = "profile_image")
-   val profileImage: String,
-   @Column(name = "phone_number")
-   val phoneNumber: String,
-   @Column(name = "address")
-   val address: String,
 
-   @Column(name = "provider_name")
-   val providerName: String?,
-   @Column(name = "provider_id")
-   val providerId: Long?
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long? = null,
+
+    @Column(name = "nickname")
+    var nickname: String,
+
+    @Column(name = "password")
+    var password: String,
+
+    @Column(name = "email")
+    var email: String,
+
+    @Column(name = "profile_image")
+    var profileImage: String,
+
+    @Column(name = "phone_number")
+    var phoneNumber: String,
+
+    @Column(name = "address")
+    var address: String,
+
+    @Column(name = "provider_name")
+    val providerName: String?,
+
+    @Column(name = "provider_id")
+    val providerId: Long?
 )

--- a/src/main/kotlin/com/highv/ecommerce/domain/buyer/entity/Buyer.kt
+++ b/src/main/kotlin/com/highv/ecommerce/domain/buyer/entity/Buyer.kt
@@ -12,7 +12,7 @@ import jakarta.persistence.Table
 class Buyer(
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long? = null,
+    var id: Long? = null,
 
     @Column(name = "nickname")
     var nickname: String,
@@ -33,8 +33,8 @@ class Buyer(
     var address: String,
 
     @Column(name = "provider_name")
-    val providerName: String?,
+    val providerName: String? = null,
 
     @Column(name = "provider_id")
-    val providerId: Long?
+    val providerId: Long? = null
 )

--- a/src/main/kotlin/com/highv/ecommerce/domain/buyer/service/BuyerService.kt
+++ b/src/main/kotlin/com/highv/ecommerce/domain/buyer/service/BuyerService.kt
@@ -3,6 +3,7 @@ package com.highv.ecommerce.domain.buyer.service
 import com.highv.ecommerce.domain.buyer.dto.request.CreateBuyerRequest
 import com.highv.ecommerce.domain.buyer.dto.request.UpdateBuyerImageRequest
 import com.highv.ecommerce.domain.buyer.dto.request.UpdateBuyerPasswordRequest
+import com.highv.ecommerce.domain.buyer.dto.request.UpdateBuyerProfileRequest
 import com.highv.ecommerce.domain.buyer.dto.response.BuyerResponse
 import com.highv.ecommerce.domain.buyer.entity.Buyer
 import com.highv.ecommerce.domain.buyer.repository.BuyerRepository
@@ -71,5 +72,23 @@ class BuyerService(
         buyer.profileImage = request.imageUrl
 
         buyerRepository.save(buyer)
+    }
+
+    fun changeProfile(request: UpdateBuyerProfileRequest, userId: Long): BuyerResponse {
+
+        val buyer = buyerRepository.findByIdOrNull(userId) ?: throw RuntimeException("사용자가 존재하지 않습니다.")
+
+        if (buyer.providerName != null) {
+            buyer.address = request.address
+            buyer.phoneNumber = request.phoneNumber
+        } else {
+            buyer.nickname = request.nickname
+            buyer.address = request.address
+            buyer.phoneNumber = request.phoneNumber
+        }
+
+        val saveBuyer = buyerRepository.save(buyer)
+
+        return BuyerResponse.from(saveBuyer)
     }
 }

--- a/src/main/kotlin/com/highv/ecommerce/domain/buyer/service/BuyerService.kt
+++ b/src/main/kotlin/com/highv/ecommerce/domain/buyer/service/BuyerService.kt
@@ -1,11 +1,14 @@
 package com.highv.ecommerce.domain.buyer.service
 
-import com.highv.ecommerce.domain.buyer.dto.BuyerResponse
-import com.highv.ecommerce.domain.buyer.dto.CreateBuyerRequest
+import com.highv.ecommerce.domain.buyer.dto.request.CreateBuyerRequest
+import com.highv.ecommerce.domain.buyer.dto.request.UpdateBuyerPasswordRequest
+import com.highv.ecommerce.domain.buyer.dto.response.BuyerResponse
 import com.highv.ecommerce.domain.buyer.entity.Buyer
 import com.highv.ecommerce.domain.buyer.repository.BuyerRepository
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class BuyerService(
@@ -33,5 +36,29 @@ class BuyerService(
         val savedBuyer = buyerRepository.save(buyer)
 
         return BuyerResponse.from(savedBuyer)
+    }
+
+    @Transactional
+    fun changePassword(request: UpdateBuyerPasswordRequest, userId: Long) {
+
+        val buyer = buyerRepository.findByIdOrNull(userId) ?: throw RuntimeException("사용자가 존재하지 않습니다.")
+
+        if (buyer.providerName != null) {
+            throw RuntimeException("소셜 로그인 사용자는 비밀번호를 변경할 수 없습니다.")
+        }
+
+        if (!passwordEncoder.matches(request.currentPassword, buyer.password)) {
+            throw RuntimeException("비밀번호가 일치하지 않습니다.")
+        }
+
+        if (request.newPassword != request.confirmNewPassword) {
+            throw RuntimeException("변경할 비밀번호와 확인 비밀번호가 다릅니다.")
+        }
+
+        if (passwordEncoder.matches(request.newPassword, buyer.password)) {
+            throw RuntimeException("현재 비밀번호와 수정할 비밀번호가 같습니다.")
+        }
+
+        buyer.password = passwordEncoder.encode(request.newPassword)
     }
 }

--- a/src/main/kotlin/com/highv/ecommerce/domain/buyer/service/BuyerService.kt
+++ b/src/main/kotlin/com/highv/ecommerce/domain/buyer/service/BuyerService.kt
@@ -1,6 +1,7 @@
 package com.highv.ecommerce.domain.buyer.service
 
 import com.highv.ecommerce.domain.buyer.dto.request.CreateBuyerRequest
+import com.highv.ecommerce.domain.buyer.dto.request.UpdateBuyerImageRequest
 import com.highv.ecommerce.domain.buyer.dto.request.UpdateBuyerPasswordRequest
 import com.highv.ecommerce.domain.buyer.dto.response.BuyerResponse
 import com.highv.ecommerce.domain.buyer.entity.Buyer
@@ -43,6 +44,7 @@ class BuyerService(
 
         val buyer = buyerRepository.findByIdOrNull(userId) ?: throw RuntimeException("사용자가 존재하지 않습니다.")
 
+
         if (buyer.providerName != null) {
             throw RuntimeException("소셜 로그인 사용자는 비밀번호를 변경할 수 없습니다.")
         }
@@ -60,5 +62,14 @@ class BuyerService(
         }
 
         buyer.password = passwordEncoder.encode(request.newPassword)
+    }
+
+    fun changeProfileImage(request: UpdateBuyerImageRequest, userId: Long) {
+
+        val buyer = buyerRepository.findByIdOrNull(userId) ?: throw RuntimeException("사용자가 존재하지 않습니다.")
+
+        buyer.profileImage = request.imageUrl
+
+        buyerRepository.save(buyer)
     }
 }

--- a/src/test/kotlin/com/highv/ecommerce/buyer/BuyerServiceTest.kt
+++ b/src/test/kotlin/com/highv/ecommerce/buyer/BuyerServiceTest.kt
@@ -41,7 +41,7 @@ class BuyerServiceTest : BehaviorSpec({
         When("현재 비밀번호와 확인 비밀번호가 일치하지 않는다면") {
 
             val request = UpdateBuyerPasswordRequest(
-                currentPassword = "testPassword",
+                currentPassword = "testPassword1",
                 newPassword = "NewPassword",
                 confirmNewPassword = "NewPassword"
             )
@@ -116,7 +116,7 @@ class BuyerServiceTest : BehaviorSpec({
 
     }
 
-    Given("비밀번호를 바꿀때") {
+    Given("소셜 로그인 이용자가") {
 
         val buyerId = 1L
         val buyer = Buyer(
@@ -130,7 +130,7 @@ class BuyerServiceTest : BehaviorSpec({
             providerName = "naver"
         )
 
-        When("소셜 로그인 사용자이면") {
+        When("비밀번호를 바꿀때") {
 
             val request = UpdateBuyerPasswordRequest(
                 currentPassword = "testPassword",
@@ -150,7 +150,7 @@ class BuyerServiceTest : BehaviorSpec({
 
     }
 
-    Given("회원이 이미지를 변경하면") {
+    Given("회원이 프로필 이미지를 변경하면") {
         val buyerId = 1L
 
         When("소셜 회원이면") {

--- a/src/test/kotlin/com/highv/ecommerce/buyer/BuyerServiceTest.kt
+++ b/src/test/kotlin/com/highv/ecommerce/buyer/BuyerServiceTest.kt
@@ -2,6 +2,7 @@ package com.highv.ecommerce.buyer
 
 import com.highv.ecommerce.domain.buyer.dto.request.UpdateBuyerImageRequest
 import com.highv.ecommerce.domain.buyer.dto.request.UpdateBuyerPasswordRequest
+import com.highv.ecommerce.domain.buyer.dto.request.UpdateBuyerProfileRequest
 import com.highv.ecommerce.domain.buyer.entity.Buyer
 import com.highv.ecommerce.domain.buyer.repository.BuyerRepository
 import com.highv.ecommerce.domain.buyer.service.BuyerService
@@ -196,6 +197,75 @@ class BuyerServiceTest : BehaviorSpec({
             }
         }
 
+    }
+
+    Given("프로필을 수정할 때") {
+
+        val buyerId = 1L
+
+        When("일반 로그인 유저이면") {
+            val buyer = Buyer(
+                nickname = "TestName",
+                email = "test@test.com",
+                profileImage = "testImage",
+                phoneNumber = "010-1234-5678",
+                address = "서울시-용산구-용산로-용산2길 19",
+                password = "testPassword",
+                providerId = null,
+                providerName = null
+            ).apply { id = buyerId }
+
+            val request: UpdateBuyerProfileRequest = UpdateBuyerProfileRequest(
+                nickname = "수정한 닉네임",
+                phoneNumber = "수정한 번호",
+                address = "수정한 주소"
+            )
+
+            every { buyerRepository.findByIdOrNull(any()) } returns buyer
+            every { buyerRepository.save(any()) } returns buyer
+
+            Then("닉네임, 핸드폰 번호, 주소가 수정된다.") {
+                val result = buyerService.changeProfile(request, buyerId)
+
+                result.nickname shouldBe "수정한 닉네임"
+                result.phoneNumber shouldBe "수정한 번호"
+                result.address shouldBe "수정한 주소"
+
+            }
+
+        }
+
+        When("소셜 로그인 유저면") {
+
+            val buyer = Buyer(
+                nickname = "TestName",
+                email = "null",
+                profileImage = "testImage",
+                phoneNumber = "null",
+                address = "null",
+                password = "testPassword",
+                providerId = 12345,
+                providerName = "kakao"
+            ).apply { id = buyerId }
+
+            val request: UpdateBuyerProfileRequest = UpdateBuyerProfileRequest(
+                nickname = "수정한 닉네임",
+                phoneNumber = "수정한 번호",
+                address = "수정한 주소"
+            )
+
+            every { buyerRepository.findByIdOrNull(any()) } returns buyer
+            every { buyerRepository.save(any()) } returns buyer
+
+            Then("핸드폰 번호, 주소만 수정된다.") {
+                val result = buyerService.changeProfile(request, buyerId)
+
+                result.nickname shouldBe "TestName"
+                result.phoneNumber shouldBe "수정한 번호"
+                result.address shouldBe "수정한 주소"
+            }
+
+        }
     }
 
 })

--- a/src/test/kotlin/com/highv/ecommerce/buyer/BuyerServiceTest.kt
+++ b/src/test/kotlin/com/highv/ecommerce/buyer/BuyerServiceTest.kt
@@ -1,5 +1,6 @@
 package com.highv.ecommerce.buyer
 
+import com.highv.ecommerce.domain.buyer.dto.request.UpdateBuyerImageRequest
 import com.highv.ecommerce.domain.buyer.dto.request.UpdateBuyerPasswordRequest
 import com.highv.ecommerce.domain.buyer.entity.Buyer
 import com.highv.ecommerce.domain.buyer.repository.BuyerRepository
@@ -55,7 +56,7 @@ class BuyerServiceTest : BehaviorSpec({
             }
         }
 
-        When("변경할 비밀번호와 변경할 비밀번호 확인 값이 다르다면") {
+        When("새 비밀번호와 확인 비밀번호 값이 다르다면") {
 
             val request = UpdateBuyerPasswordRequest(
                 currentPassword = "testPassword",
@@ -75,7 +76,7 @@ class BuyerServiceTest : BehaviorSpec({
             }
         }
 
-        When("현재 비밀번호와 변경할 비밀번호가 같다면") {
+        When("변경 전 비밀번호와 변경 후 비밀번호가 같다면") {
             val request = UpdateBuyerPasswordRequest(
                 currentPassword = "testPassword",
                 newPassword = "testPassword",
@@ -95,7 +96,7 @@ class BuyerServiceTest : BehaviorSpec({
             }
         }
 
-        When("현재 비밀번호 확인도 맞고 변경할 비밀번호와 현재 비밀번호가 다르다면") {
+        When("모든 조건이 만족될 경우") {
             val request = UpdateBuyerPasswordRequest(
                 currentPassword = "testPassword",
                 newPassword = "testPassword1",
@@ -143,6 +144,55 @@ class BuyerServiceTest : BehaviorSpec({
                 }.apply {
                     message shouldBe "소셜 로그인 사용자는 비밀번호를 변경할 수 없습니다."
                 }
+            }
+        }
+
+    }
+
+    Given("회원이 이미지를 변경하면") {
+        val buyerId = 1L
+
+        When("소셜 회원이면") {
+            val buyer = Buyer(
+                nickname = "TestName",
+                email = "null",
+                profileImage = "testImage",
+                phoneNumber = "null",
+                address = "null",
+                password = "null",
+                providerId = 123132,
+                providerName = "naver"
+            )
+
+            val request = UpdateBuyerImageRequest("updateTestImage")
+
+            every { buyerRepository.findByIdOrNull(any()) } returns buyer.apply { id = buyerId }
+            every { buyerRepository.save(any()) } returns buyer
+
+            Then("이미지가 변경된다.") {
+                buyerService.changeProfileImage(request, buyerId)
+            }
+        }
+
+        When("일반 회원이면") {
+            val buyer = Buyer(
+                nickname = "TestName",
+                email = "test@test.com",
+                profileImage = "testImage",
+                phoneNumber = "010-1234-5678",
+                address = "서울시-용산구-용산로-용산2길 19",
+                password = "testPassword",
+                providerId = null,
+                providerName = null
+            )
+
+            val request = UpdateBuyerImageRequest("updateTestImage")
+
+            every { buyerRepository.findByIdOrNull(any()) } returns buyer.apply { id = buyerId }
+            every { buyerRepository.save(any()) } returns buyer
+
+            Then("이미지가 변경된다.") {
+                buyerService.changeProfileImage(request, buyerId)
             }
         }
 

--- a/src/test/kotlin/com/highv/ecommerce/buyer/BuyerServiceTest.kt
+++ b/src/test/kotlin/com/highv/ecommerce/buyer/BuyerServiceTest.kt
@@ -1,4 +1,151 @@
 package com.highv.ecommerce.buyer
 
-class BuyerServiceTest {
-}
+import com.highv.ecommerce.domain.buyer.dto.request.UpdateBuyerPasswordRequest
+import com.highv.ecommerce.domain.buyer.entity.Buyer
+import com.highv.ecommerce.domain.buyer.repository.BuyerRepository
+import com.highv.ecommerce.domain.buyer.service.BuyerService
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.security.crypto.password.PasswordEncoder
+
+class BuyerServiceTest : BehaviorSpec({
+    val buyerRepository: BuyerRepository = mockk<BuyerRepository>()
+    val passwordEncoder: PasswordEncoder = mockk<PasswordEncoder>()
+    val buyerService: BuyerService = BuyerService(buyerRepository, passwordEncoder)
+
+    afterEach {
+        clearAllMocks()
+    }
+
+    Given("일반 회원이 비밀번호를 바꿀 때") {
+        val buyerId = 1L
+        val buyer = Buyer(
+            nickname = "TestName",
+            email = "test@test.com",
+            profileImage = "testImage",
+            phoneNumber = "010-1234-5678",
+            address = "서울시-용산구-용산로-용산2길 19",
+            password = "testPassword",
+            providerId = null,
+            providerName = null
+        )
+
+
+        When("현재 비밀번호와 확인 비밀번호가 일치하지 않는다면") {
+
+            val request = UpdateBuyerPasswordRequest(
+                currentPassword = "testPassword",
+                newPassword = "NewPassword",
+                confirmNewPassword = "NewPassword"
+            )
+            every { buyerRepository.findByIdOrNull(any()) } returns buyer.apply { id = buyerId }
+            every { passwordEncoder.matches(any(), any()) } returns false
+
+            Then("예외가 발생한다.") {
+                shouldThrow<RuntimeException> {
+                    buyerService.changePassword(request, buyerId)
+                }.run {
+                    message shouldBe "비밀번호가 일치하지 않습니다."
+                }
+            }
+        }
+
+        When("변경할 비밀번호와 변경할 비밀번호 확인 값이 다르다면") {
+
+            val request = UpdateBuyerPasswordRequest(
+                currentPassword = "testPassword",
+                newPassword = "NewPassword",
+                confirmNewPassword = "NewPassword1"
+            )
+
+            every { buyerRepository.findByIdOrNull(any()) } returns buyer.apply { id = buyerId }
+            every { passwordEncoder.matches(any(), any()) } returns true
+
+            Then("예외가 발생한다.") {
+                shouldThrow<RuntimeException> {
+                    buyerService.changePassword(request, buyerId)
+                }.run {
+                    message shouldBe "변경할 비밀번호와 확인 비밀번호가 다릅니다."
+                }
+            }
+        }
+
+        When("현재 비밀번호와 변경할 비밀번호가 같다면") {
+            val request = UpdateBuyerPasswordRequest(
+                currentPassword = "testPassword",
+                newPassword = "testPassword",
+                confirmNewPassword = "testPassword"
+            )
+
+            every { buyerRepository.findByIdOrNull(any()) } returns buyer.apply { id = buyerId }
+            every { passwordEncoder.matches(request.currentPassword, buyer.password) } returns true
+            every { passwordEncoder.matches(request.newPassword, buyer.password) } returns true
+
+            Then("예외가 발생한다.") {
+                shouldThrow<RuntimeException> {
+                    buyerService.changePassword(request, buyerId)
+                }.run {
+                    message shouldBe "현재 비밀번호와 수정할 비밀번호가 같습니다."
+                }
+            }
+        }
+
+        When("현재 비밀번호 확인도 맞고 변경할 비밀번호와 현재 비밀번호가 다르다면") {
+            val request = UpdateBuyerPasswordRequest(
+                currentPassword = "testPassword",
+                newPassword = "testPassword1",
+                confirmNewPassword = "testPassword1"
+            )
+
+            every { buyerRepository.findByIdOrNull(any()) } returns buyer.apply { id = buyerId }
+            every { passwordEncoder.matches(request.currentPassword, buyer.password) } returns true
+            every { passwordEncoder.matches(request.newPassword, buyer.password) } returns false
+            every { passwordEncoder.encode(any()) } returns "testPassword1"
+
+            Then("비밀번호가 변경된다.") {
+                buyerService.changePassword(request, buyerId)
+            }
+        }
+
+    }
+
+    Given("비밀번호를 바꿀때") {
+
+        val buyerId = 1L
+        val buyer = Buyer(
+            nickname = "TestName",
+            email = "null",
+            profileImage = "testImage",
+            phoneNumber = "null",
+            address = "null",
+            password = "null",
+            providerId = 123132,
+            providerName = "naver"
+        )
+
+        When("소셜 로그인 사용자이면") {
+
+            val request = UpdateBuyerPasswordRequest(
+                currentPassword = "testPassword",
+                newPassword = "testPassword1",
+                confirmNewPassword = "testPassword1"
+            )
+            every { buyerRepository.findByIdOrNull(any()) } returns buyer.apply { id = buyerId }
+
+            Then("예외가 발생한다.") {
+                shouldThrow<RuntimeException> {
+                    buyerService.changePassword(request, buyerId)
+                }.apply {
+                    message shouldBe "소셜 로그인 사용자는 비밀번호를 변경할 수 없습니다."
+                }
+            }
+        }
+
+    }
+
+})

--- a/src/test/kotlin/com/highv/ecommerce/buyer/BuyerServiceTest.kt
+++ b/src/test/kotlin/com/highv/ecommerce/buyer/BuyerServiceTest.kt
@@ -1,0 +1,4 @@
+package com.highv.ecommerce.buyer
+
+class BuyerServiceTest {
+}


### PR DESCRIPTION
## 요약
> 구매자의 프로필 변경 구현입니다.

## 작업 사항

닉네임, 핸드폰 번호, 주소 변경을 하나의 API로 구현했습니다.
> 소셜 회원은 핸드폰 번호와, 주소 변경만 가능합니다.
> 일반 회원은 전체를 다 변경합니다.

패스워드 변경 - Patch
> 소셜 회원은 변경할 수 없게 했습니다.
> 일반 회원은 변경이 가능합니다.

프로필 변경 - Patch
> 소셜, 일반 회원 모두 변경이 가능합니다.


---
### 해결한 이슈
closes: #14 
